### PR TITLE
dag: add workflow to run builds on K8s using dag

### DIFF
--- a/.github/workflows/dag-push-staging.yaml
+++ b/.github/workflows/dag-push-staging.yaml
@@ -1,0 +1,79 @@
+name: Build Packages Staging using dag
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build stage1 packages using dag
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      PROJECT: staging-images-183e
+      CLUSTER_NAME: tmp-cluster
+      CLUSTER_ZONE: us-central1-b
+
+    steps:
+      # Checkout and build dag from main
+      # Can't `go install` because its go.mod has `replace`s.
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.19.0'
+      - uses: actions/checkout@v3
+        with:
+          repository: wolfi-dev/dag
+          path: ./dag
+      - working-directory: ./dag
+        run: go install
+
+      - uses: actions/checkout@v3
+
+      - uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: "projects/567187841907/locations/global/workloadIdentityPools/staging-shared-9bd2/providers/staging-shared-gha"
+          service_account: "staging-images-ci@staging-images-183e.iam.gserviceaccount.com"
+      - uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: ${{env.PROJECT}}
+
+      - name: Setup Build Cluster
+        working-directory: ./dag
+        run: |
+          gcloud container clusters create ${CLUSTER_NAME} \
+            --zone            ${CLUSTER_ZONE}  \
+            --release-channel rapid \
+            --workload-pool   "${PROJECT}.svc.id.goog" \
+            --machine-type    e2-standard-32 \
+            --num-nodes       1
+
+          gcloud container node-pools create arm-nodes \
+            --cluster        ${CLUSTER_NAME} \
+            --zone           ${CLUSTER_ZONE} \
+            --machine-type   t2a-standard-32 \
+            --num-nodes      1
+
+          ./scripts/setup-cluster.sh
+
+      # NB: These publish to a separate path in the staging bucket until they're ready.
+      - run: |
+          dag pod \
+            --cpu=30 --ram=100Gi \
+            --bucket=wolfi-registry-source/dag-test/bootstrap/stage1 \
+            --secret-key
+      - run: |
+          dag pod \
+            --cpu=30 --ram=100Gi \
+            --bucket=wolfi-registry-source/dag-test/bootstrap/stage1 \
+            --secret-key \
+            --arch=arm64
+
+      - name: Teardown Build Cluster
+        if: ${{ always() }}
+        run: gcloud container clusters delete tmp-cluster --location=${CLUSTER_ZONE}

--- a/.github/workflows/dag-push-staging.yaml
+++ b/.github/workflows/dag-push-staging.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - dag
 
 jobs:
   build:

--- a/.github/workflows/dag-push-staging.yaml
+++ b/.github/workflows/dag-push-staging.yaml
@@ -65,12 +65,12 @@ jobs:
       - run: |
           dag pod \
             --cpu=30 --ram=100Gi \
-            --bucket=wolfi-registry-source/dag-test/bootstrap/stage1 \
+            --bucket=wolfi-dag-test-bucket/dag-test/bootstrap/stage1 \
             --secret-key
       - run: |
           dag pod \
             --cpu=30 --ram=100Gi \
-            --bucket=wolfi-registry-source/dag-test/bootstrap/stage1 \
+            --bucket=wolfi-dag-test-bucket/dag-test/bootstrap/stage1 \
             --secret-key \
             --arch=arm64
 


### PR DESCRIPTION
This creates a cluster with x86 and arm nodes, runs a build on each, and deletes the cluster.

It (attempts to) set up GKE Workload Identity to use Service Account creds to fetch the melange signing key in GCP Secret Manager, and to push built packages to GCS.

It uses GH OIDC Federation to auth to GCP.

Signed-off-by: Jason Hall <jason@chainguard.dev>