### PR TITLE
allow ARCH to be overridden, which enables proot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
-ARCH := $(shell uname -m)
+ARCH ?= $(shell uname -m)
 MELANGE_DIR ?= ../melange
 MELANGE ?= ${MELANGE_DIR}/melange
 KEY ?= local-melange.rsa
 REPO ?= $(shell pwd)/packages
+
+ifeq ($(ARCH), $(shell uname -m))
+	USE_PROOT=false
+else
+	USE_PROOT=true
+endif
 
 BINUTILS_VERSION ?= 2.39-r0
 GCC_VERSION ?= 12.2.0-r2
@@ -16,7 +22,8 @@ MELANGE_OPTS ?= \
 	--signing-key ${KEY} \
 	--pipeline-dir ${MELANGE_DIR}/pipelines \
 	--arch ${ARCH} \
-	--empty-workspace
+	--empty-workspace \
+	--use-proot=${USE_PROOT}
 
 PACKAGES = \
 	packages/${ARCH}/cross-binutils-stage1-${BINUTILS_VERSION}.apk \


### PR DESCRIPTION
Found this while starting to experiment with running armv7 builds in dag. This lets us run

```
ARCH=armv7 make all
```

which results in `--use-proot=true` if not being natively run on that architecture.